### PR TITLE
Fix link syntax

### DIFF
--- a/install.fish
+++ b/install.fish
@@ -5,7 +5,7 @@ set -g config "$HOME/.config"
 set -g share "$HOME/.local/share"
 
 function link-fish
-    ln -s $cwd/fish $config/fish
+    ln -s $cwd/fish $config/
 end
 
 function link-fonts


### PR DESCRIPTION
Used to create a link to the folder inside the folder, meaning `fish` would be considered a directory and a link named `fish` will be created inside of it